### PR TITLE
Fix GitGuardian alert - that github clientId secret was published

### DIFF
--- a/delis-test-server/delis-index-files/html/index.html
+++ b/delis-test-server/delis-index-files/html/index.html
@@ -78,7 +78,7 @@
 					Corner Blue
 				</div>
 				<div class="card-body">
-				  <h4><a href="/domibus1" target="_blank">DOMIBUS 4.1.2 - blue</a></h4>
+				  <h4><a href="/domibus1" target="_blank">DOMIBUS 4.2.5 - blue</a></h4>
 				  <p>AS4 access point 1 (clustered, mutliple intsances)</p>
 
 				  <h4><a href="/jmx1" target="_blank">ActiveMQ 5.14.3 - blue</a></h4>
@@ -98,7 +98,7 @@
 					Corner Red
 				</div>
 				<div class="card-body">
-				  <h4><a href="/domibus2" target="_blank">DOMIBUS 4.1.2 - red</a></h4>
+				  <h4><a href="/domibus2" target="_blank">DOMIBUS 4.2.5 - red</a></h4>
 				  <p>Internal AS4 access point 2</p>
 
 				  <h4><a href="/oxalis2/status" target="_blank">OXALIS 4.0.4 - red</a></h4>

--- a/delis-test-server/helm/edelivery-test/templates/test-web-console.dep.yaml
+++ b/delis-test-server/helm/edelivery-test/templates/test-web-console.dep.yaml
@@ -42,11 +42,11 @@ spec:
         - name: config.authSsoEnabled
           value: 'true'
         - name: config.authSsoUserList
-          value: ';dladlk;alexgeta;apalefisco;iegor-funtusov;olemad;tonsv2;hmkgithub;'
+          value: ';dladlk;apalefisco;olemad;'
         - name: github.client.clientId
-          value: ae3d961de8435398f7c6 
+          value: '{{.Values.tw.env.githubClientId}}'
         - name: github.client.clientSecret
-          value: 1dc4341d86ac7524ba4c8044296dd86daab9c84f
+          value: '{{.Values.tw.env.githubClientSecret}}'
         - name: SERVER_SERVLET_CONTEXT-PATH
           value: '/twc'
         - name: SERVER_TOMCAT_ACCESSLOG_ENABLED

--- a/delis-test-server/helm/edelivery-test/values.yaml
+++ b/delis-test-server/helm/edelivery-test/values.yaml
@@ -9,8 +9,10 @@ tw:
   imageTag: latest
   imagePullPolicy: IfNotPresent
   env:
-    javaopts: -Xmx384m -XX:MaxMetaspaceSize=128m -Dgithub.client.clientId=ae3d961de8435398f7c6 -Dgithub.client.clientSecret=1dc4341d86ac7524ba4c8044296dd86daab9c84f
+    javaopts: -Xmx384m -XX:MaxMetaspaceSize=128m
     filesRoot: /data/fs
+    githubClientId: FILL_clientId
+    githubClientSecret: FILL_clientSecret
     keystoresRoot: /data/keystores
     filesDeploymentLogs: /data/deployment_logs
 bind:

--- a/delis-test-server/helm/install-edelivery-test.sh
+++ b/delis-test-server/helm/install-edelivery-test.sh
@@ -1,3 +1,6 @@
 #!/bin/bash -ex
 CURDIR=`dirname $0`
-helm tiller run helm upgrade edelivery-test --install --force ${CURDIR}/edelivery-test/
+helm tiller run helm upgrade edelivery-test --install \
+	--force ${CURDIR}/edelivery-test/ \
+	--values ${CURDIR}/local-only/install-edelivery-test.yaml
+


### PR DESCRIPTION
Fix GitGuardian alert - that github clientId secret was published in src. Revoked secret, moved secret passing via local-only helm value